### PR TITLE
Fix non-ASCII

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,26 @@
+Metrics/AbcSize:
+  Enabled: false
+
+Metrics/ClassLength:
+  Enabled: false
+
+Metrics/CyclomaticComplexity:
+  Enabled: false
+
+Metrics/LineLength:
+  Max: 90
+
+Metrics/MethodLength:
+  Enabled: false
+
+Metrics/PerceivedComplexity:
+  Enabled: false
+
+# I'm going to use the whole Unicode until I run into problems. Because progress.
+# And because people have weird names.
+#   - Adam Wróbel
+Style/AsciiComments:
+  Enabled: false
+
+Style/StringLiterals:
+  EnforcedStyle: double_quotes

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,32 @@
+language: ruby
+
+sudo: false
+
+rvm:
+  - 1.9.3
+  - 2.0.0
+  - 2.1
+  - 2.2
+  - jruby
+
+gemfile:
+  - Gemfile
+
+env:
+  global:
+    - CI="travis"
+    - JRUBY_OPTS="--server -J-Xms512m -J-Xmx1024m"
+  matrix:
+    - MONGODB=2.4.14
+    - MONGODB=2.6.11
+    - MONGODB=3.0.7
+    - MONGODB=3.2.0-rc3
+
+before_script:
+  - wget http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-${MONGODB}.tgz -O /tmp/mongodb.tgz
+  - tar -xvf /tmp/mongodb.tgz
+  - mkdir /tmp/data
+  - ${PWD}/mongodb-linux-x86_64-${MONGODB}/bin/mongod --dbpath /tmp/data --bind_ip 127.0.0.1 --noauth &> /dev/null &
+
+notifications:
+  email: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+## 1.1.0 (2016-01-04)
+
+- Add `_plural_scopes` option to better fit noun values, e.g. `Book.comedies`,
+  `Attachment.videos`
+
+## 1.0.0 (2015-11-22)
+
+- Initial release

--- a/lib/mongoid/enum/enum_type.rb
+++ b/lib/mongoid/enum/enum_type.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 module Mongoid
   module Enum
     # Internal: Mapping wrapper used as type for enum fields.

--- a/lib/mongoid/enum/invalid_key.rb
+++ b/lib/mongoid/enum/invalid_key.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 module Mongoid
   module Enum
     # raised when InvalidKey is forced to be saved in DB (skipping validation)

--- a/lib/mongoid/enum/invalid_value.rb
+++ b/lib/mongoid/enum/invalid_value.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 module Mongoid
   module Enum
     # Public: Wraps invalid values loaded from DB before returning them via getter.

--- a/lib/mongoid_enum.rb
+++ b/lib/mongoid_enum.rb
@@ -1,2 +1,1 @@
-# encoding: utf-8
 require "mongoid/enum"

--- a/mongoid.yml
+++ b/mongoid.yml
@@ -1,0 +1,6 @@
+development:
+  clients:
+    default:
+      database: enum_test
+      hosts:
+        - localhost:27017

--- a/mongoid_enum.gemspec
+++ b/mongoid_enum.gemspec
@@ -1,8 +1,6 @@
-# encoding: utf-8
-
 Gem::Specification.new do |s|
   s.name        = "mongoid_enum"
-  s.version     = "1.1.4"
+  s.version     = "1.1.5"
   s.summary     = "Enum fields for Mongoid"
   s.description = "Fields with closed set of possible values and helper methods to query/set them by label."
   s.authors     = ["Adam Wróbel"]

--- a/test/factories/book.rb
+++ b/test/factories/book.rb
@@ -1,0 +1,41 @@
+class Book
+  include Mongoid::Document
+  include Mongoid::Enum
+
+  field :author_id, type: BSON::ObjectId
+  field :format, type: String
+  field :name, type: String
+
+  enum status: [:proposed, :written, :published]
+  # {"read": 3} conflicts with Mongoid read options so it's "finished" instead
+  enum read_status: { unread: 0, reading: 2, finished: 3 }
+  enum nullable_status: [:single, :married]
+  enum language: [:english, :spanish, :french], _prefix: :in
+  enum author_visibility: [:visible, :invisible], _prefix: true
+  enum illustrator_visibility: [:visible, :invisible], _prefix: true
+  enum font_size: { small: 8, medium: 10, large: 12 }, _prefix: :with,
+       _suffix: true, _default: :medium
+  enum quality_control: { pending: nil, passed: true, failed: false }, _prefix: :qc
+  enum genre: %w(drama comedy thriller), _plural_scopes: true
+
+  def published!
+    super
+    "do publish work..."
+  end
+end
+
+FactoryGirl.define do
+  factory :book do
+    format "paperback"
+    status :published
+    read_status :finished
+    language :english
+    author_visibility :visible
+    illustrator_visibility :visible
+    font_size :medium
+    genre :comedy
+  end
+
+  factory :default_book, class: Book do
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,35 @@
+require "active_support"
+require "active_support/test_case"
+require "active_support/logger"
+require "active_support/testing/autorun"
+require "factory_girl"
+require "mongoid"
+require "mongoid/enum"
+
+ActiveSupport.test_order = :random
+
+module ActiveSupport
+  class TestCase
+    include FactoryGirl::Syntax::Methods
+  end
+end
+
+FactoryGirl.find_definitions
+
+# wait until MongoDB instance is ready
+if ENV["CI"] == "travis"
+  starting = true
+  client = Mongo::Client.new(["127.0.0.1:27017"])
+  while starting
+    begin
+      client.command(Mongo::Server::Monitor::Connection::ISMASTER)
+      break
+    rescue Mongo::Error::OperationFailure
+      sleep(2)
+      client.cluster.scan!
+    end
+  end
+end
+
+Mongoid.load!("mongoid.yml", :development)
+Mongo::Logger.logger = Logger.new("log/test.log")

--- a/test/unit/enum_test.rb
+++ b/test/unit/enum_test.rb
@@ -1,0 +1,409 @@
+require "test_helper"
+
+class EnumTest < ActiveSupport::TestCase
+  def new_book_class(&block)
+    klass = Class.new do
+      include Mongoid::Document
+      include Mongoid::Enum
+
+      def self.name
+        "Book"
+      end
+
+      store_in collection: "books"
+    end
+
+    klass.class_eval(&block) if block_given?
+
+    klass
+  end
+
+  setup do
+    @book = create(:book)
+  end
+
+  test "query state by predicate" do
+    assert @book.published?
+    assert_not @book.written?
+    assert_not @book.proposed?
+
+    assert @book.finished?
+    assert @book.in_english?
+    assert @book.author_visibility_visible?
+    assert @book.illustrator_visibility_visible?
+    assert @book.with_medium_font_size?
+  end
+
+  test "query state with strings" do
+    assert_equal "published", @book.status
+    assert_equal "finished", @book.read_status
+    assert_equal "english", @book.language
+    assert_equal "visible", @book.author_visibility
+    assert_equal "visible", @book.illustrator_visibility
+  end
+
+  test "find via scope" do
+    assert_equal @book, Book.published.desc(:_id).first
+    assert_equal @book, Book.finished.desc(:_id).first
+    assert_equal @book, Book.in_english.desc(:_id).first
+    assert_equal @book, Book.author_visibility_visible.desc(:_id).first
+    assert_equal @book, Book.illustrator_visibility_visible.desc(:_id).first
+    assert_equal @book, Book.comedies.desc(:_id).first
+  end
+
+  test "find via where with labels" do
+    assert_equal @book, Book.where(status: :published).desc(:_id).first
+    assert_not_equal @book, Book.where(status: :written).desc(:_id).first
+    assert_equal @book, Book.where(:read_status.in => [:finished]).desc(:_id).first
+    assert_not_equal @book, Book.where(:read_status.in => [:reading]).desc(:_id).first
+  end
+
+  test "find via where with values" do
+    published = Book::STATUSES[:published]
+    written = Book::STATUSES[:written]
+    reading = Book::READ_STATUSES["reading"]
+    finished = Book::READ_STATUSES["finished"]
+
+    assert_equal @book, Book.where(status: published).desc(:_id).first
+    assert_not_equal @book, Book.where(status: written).desc(:_id).first
+    assert_equal @book, Book.where(:read_status.in => [finished]).desc(:_id).first
+    assert_not_equal @book, Book.where(:read_status.in => [reading]).desc(:_id).first
+  end
+
+  test "update by declaration" do
+    assert @book.published?
+    @book.written!
+    assert @book.written?
+    assert_not @book.published?
+    @book.in_english!
+    assert @book.in_english?
+    @book.author_visibility_visible!
+    assert @book.author_visibility_visible?
+  end
+
+  test "update by setter" do
+    @book.update! status: :written, read_status: :reading
+    assert @book.written?
+    assert_not @book.published?
+    assert @book.reading?
+    assert_not @book.finished?
+  end
+
+  test "nil is allowed value" do
+    assert @book.qc_pending?
+    assert_nil @book["quality_control"]
+    assert_equal @book.id, Book.qc_pending.desc(:_id).first.id
+    @book.qc_passed!
+    assert_not_equal @book, Book.qc_pending.desc(:_id).first
+  end
+
+  test "atomic set on instance" do
+    assert_equal "finished", @book.read_status
+    @book.set read_status: :reading
+    assert_equal "reading", @book.read_status
+    assert_equal 2, @book["read_status"]
+    @book.reload
+    assert_equal "reading", @book.read_status
+    assert_equal 2, @book["read_status"]
+  end
+
+  test "atomic set on scope" do
+    assert_equal "finished", @book.read_status
+    Book.where(_id: @book.id).set read_status: Book::READ_STATUSES[:reading]
+    @book.reload
+    assert_equal "reading", @book.read_status
+    assert_equal 2, @book["read_status"]
+  end
+
+  test "enum methods are overwritable" do
+    assert_equal "do publish work...", @book.published!
+    assert @book.published?
+  end
+
+  test "direct symbol assignment" do
+    @book.status = :written
+    assert @book.written?
+  end
+
+  test "direct string assignment" do
+    @book.status = "written"
+    assert @book.written?
+  end
+
+  test "remembers invalid assignment" do
+    @book.status = "invalid-status-key"
+    assert_not @book.written?
+    assert_equal "invalid-status-key", @book.status
+  end
+
+  test "reports invalid assignment" do
+    @book.status = "invalid-status-key"
+    assert_not @book.written?
+    assert_not @book.valid?
+    assert_equal ["Status is invalid"], @book.errors.full_messages
+  end
+
+  test "raises on save skipping validation" do
+    @book.status = "invalid-status-key"
+    assert_not @book.written?
+    assert_not @book.valid?
+    e = assert_raises Mongoid::Enum::InvalidKeyError do
+      @book.save validate: false
+    end
+    assert_equal "invalid enum key: invalid-status-key", e.message
+  end
+
+  test "reports invalid value read from db" do
+    Book.where(_id: @book.id).set read_status: 10
+    @book.reload
+    assert_not @book.finished?
+    assert_not @book.valid?
+    assert_equal ["Read status is invalid"], @book.errors.full_messages
+    assert_equal 10, @book["read_status"]
+    assert @book.read_status.is_a? Mongoid::Enum::InvalidValue
+    assert_equal 10, @book.read_status.database_value
+  end
+
+  test "enum changed attributes" do
+    old_status = @book.status
+    old_language = @book.language
+    @book.status = :proposed
+    @book.language = :spanish
+    assert_equal Book::STATUSES[old_status], @book.changed_attributes["status"]
+    assert_equal Book::LANGUAGES[old_language], @book.changed_attributes["language"]
+  end
+
+  test "enum changes" do
+    old_status = @book.status
+    old_language = @book.language
+    @book.status = :proposed
+    @book.language = :spanish
+    assert_equal [old_status, "proposed"], @book.changes["status"]
+    assert_equal [old_language, "spanish"], @book.changes["language"]
+    assert_equal [old_status, "proposed"], @book.status_change
+    assert_equal [old_language, "spanish"], @book.language_change
+  end
+
+  test "enum attribute changed" do
+    @book.status = :proposed
+    @book.language = :french
+    assert @book.status_changed?
+    assert @book.language_changed?
+  end
+
+  test "enum didn't change" do
+    old_status = @book.status
+    @book.status = old_status
+    assert_not @book.status_changed?
+  end
+
+  test "persist changes that are dirty" do
+    @book.status = :proposed
+    assert @book.status_changed?
+    @book.status = :written
+    assert @book.status_changed?
+  end
+
+  test "reverted changes that are not dirty" do
+    old_status = @book.status
+    @book.status = :proposed
+    assert @book.status_changed?
+    @book.status = old_status
+    assert_not @book.status_changed?
+  end
+
+  test "reverted changes are not dirty going from nil to value and back" do
+    book = Book.create!(nullable_status: nil)
+
+    book.nullable_status = :married
+    assert book.nullable_status_changed?
+
+    book.nullable_status = nil
+    assert_not book.nullable_status_changed?
+  end
+
+  test "NULL values from database should be casted to nil" do
+    Book.where(id: @book.id).update_all(status: nil)
+    assert_nil @book.reload.status
+  end
+
+  test "assign nil value" do
+    @book.status = nil
+    assert_nil @book.status
+  end
+
+  test "assign empty string value" do
+    @book.status = ""
+    assert_nil @book.status
+  end
+
+  test "assign long empty string value" do
+    @book.status = "   "
+    assert_nil @book.status
+  end
+
+  test "constant to access the mapping" do
+    assert_equal 0, Book::READ_STATUSES[:unread]
+    assert_equal 2, Book::READ_STATUSES["reading"]
+    assert_equal 3, Book::READ_STATUSES[:finished]
+  end
+
+  test "building new objects with enum scopes" do
+    assert Book.written.build.written?
+    assert_not Book.written.build.proposed?
+    assert Book.thrillers.build.thriller?
+    assert_not Book.thrillers.build.comedy?
+    assert Book.finished.build.finished?
+    assert Book.reading.build.reading?
+    assert Book.in_spanish.build.in_spanish?
+    assert Book.illustrator_visibility_invisible.build.illustrator_visibility_invisible?
+  end
+
+  test "creating new objects with enum scopes" do
+    assert Book.written.create.written?
+    assert_not Book.written.create.proposed?
+    assert Book.thrillers.create.thriller?
+    assert_not Book.thrillers.create.comedy?
+    assert Book.finished.create.finished?
+    assert Book.reading.create.reading?
+    assert Book.in_spanish.create.in_spanish?
+    assert Book.illustrator_visibility_invisible.create.illustrator_visibility_invisible?
+  end
+
+  test "_before_type_cast returns the enum label (required for form fields)" do
+    assert_equal :published, @book.status_before_type_cast
+    assert_equal :finished, @book.read_status_before_type_cast
+    @book.status = 123
+    assert_equal 123, @book.status_before_type_cast
+  end
+
+  test "reserved enum names" do
+    klass = new_book_class do
+      enum status: [:proposed, :written, :published]
+      field :conflicting_field
+    end
+
+    conflicts = [:save, :attributes, :conflicting_field]
+
+    conflicts.each_with_index do |name, i|
+      e = assert_raises(ArgumentError) do
+        klass.class_eval { enum name => ["value_#{i}"] }
+      end
+      assert_match(
+        /You tried to define an enum named \"#{name}\" on the model/,
+        e.message
+      )
+    end
+  end
+
+  test "reserved enum values" do
+    klass = new_book_class do
+      enum status: [:proposed, :written, :published]
+    end
+
+    conflicts = [
+      :new,      # generates a scope that conflicts with an AR class method
+      :valid,    # generates #valid?, which conflicts with an AR method
+      :save,     # generates #save!, which conflicts with an AR method
+      :proposed, # same value as an existing enum
+      :public, :private, :protected, # some important methods on Module and Class
+      :name, :parent, :superclass
+    ]
+
+    conflicts.each_with_index do |value, i|
+      e = assert_raises(ArgumentError, "enum value `#{value}` should not be allowed") do
+        klass.class_eval { enum "status_#{i}" => [value] }
+      end
+      assert_match(/You tried to define an enum named .* on the model/, e.message)
+    end
+  end
+
+  test "validate uniqueness" do
+    klass = new_book_class do
+      enum read_status: { unread: 0, reading: 2, finished: 3 }
+      validates_uniqueness_of :read_status
+    end
+
+    klass.delete_all
+    klass.create!(read_status: "reading")
+    book = klass.new(read_status: "unread")
+    assert book.valid?
+    book.read_status = "reading"
+    assert_not book.valid?
+  end
+
+  test "enums are distinct per class" do
+    klass1 = new_book_class do
+      enum status: [:proposed, :written]
+    end
+
+    klass2 = new_book_class do
+      enum status: [:drafted, :uploaded]
+    end
+
+    book1 = klass1.proposed.create!
+    book1.status = :written
+    assert_equal %w(proposed written), book1.status_change
+
+    book2 = klass2.drafted.create!
+    book2.status = :uploaded
+    assert_equal %w(drafted uploaded), book2.status_change
+  end
+
+  test "enums are inheritable" do
+    subklass1 = Class.new(Book)
+
+    subklass2 = Class.new(Book) do
+      enum status2: [:drafted, :uploaded]
+    end
+
+    book1 = subklass1.proposed.create!
+    book1.status = :written
+    assert_equal %w(proposed written), book1.status_change
+
+    book2 = subklass2.drafted.create!
+    book2.status2 = :uploaded
+    assert_equal %w(drafted uploaded), book2.status2_change
+  end
+
+  test "declare multiple enums at a time" do
+    klass = new_book_class do
+      enum status: [:proposed, :written, :published],
+           nullable_status: [:single, :married]
+    end
+
+    book1 = klass.proposed.create!
+    assert book1.proposed?
+
+    book2 = klass.single.create!
+    assert book2.single?
+  end
+
+  test "query state by predicate with prefix" do
+    assert @book.author_visibility_visible?
+    assert_not @book.author_visibility_invisible?
+    assert @book.illustrator_visibility_visible?
+    assert_not @book.illustrator_visibility_invisible?
+  end
+
+  test "query state by predicate with custom prefix" do
+    assert @book.in_english?
+    assert_not @book.in_spanish?
+    assert_not @book.in_french?
+  end
+
+  test "uses default status when no status is provided in fixtures" do
+    book = build(:default_book)
+    assert_nil book.status
+    assert book.with_medium_font_size?
+    assert_equal 10, book["font_size"]
+    assert_equal "medium", book.font_size
+  end
+
+  test "exposes defined enums" do
+    assert Book.enums
+    assert Book.enums[:read_status]
+    assert_equal 2, Book.enums[:read_status]["reading"]
+    assert_equal 2, Book.enums[:read_status][:reading]
+  end
+end


### PR DESCRIPTION
I revert to stable version, before docker test. This PR changes line breaks "\", cause docker container detects them as non ASCII chars.